### PR TITLE
Support subdomain matching

### DIFF
--- a/app/controllers/sites_controller.rb
+++ b/app/controllers/sites_controller.rb
@@ -50,6 +50,6 @@ class SitesController < ApplicationController
   end
 
   def site_params
-    params.expect(site: [ :name, :domain ])
+    params.expect(site: [ :name, :domain, :match_subdomains ])
   end
 end

--- a/app/jobs/keyword_check_job.rb
+++ b/app/jobs/keyword_check_job.rb
@@ -31,7 +31,7 @@ class KeywordCheckJob < ApplicationJob
     )
 
     targets.each do |target|
-      result = client.extract_position(results, target.site.domain)
+      result = client.extract_position(results, target.site.domain, match_subdomains: target.site.match_subdomains)
       create_check(keyword, target, search_run, result.merge(status: :success))
     end
 

--- a/app/jobs/missing_checks_backfill_job.rb
+++ b/app/jobs/missing_checks_backfill_job.rb
@@ -49,7 +49,7 @@ class MissingChecksBackfillJob < ApplicationJob
   end
 
   def create_success_check(target, search_run, results)
-    result = SerpApiClient.new.extract_position(results, target.site.domain)
+    result = SerpApiClient.new.extract_position(results, target.site.domain, match_subdomains: target.site.match_subdomains)
 
     target.checks.create!(
       keyword: target.keyword,

--- a/app/services/serp_api_client.rb
+++ b/app/services/serp_api_client.rb
@@ -11,13 +11,13 @@ class SerpApiClient
     client&.close
   end
 
-  def extract_position(results, domain)
+  def extract_position(results, domain, match_subdomains: false)
     organic = results[:organic_results] || []
-    match = organic.each_with_index.find { |result, _| result[:link]&.include?(domain) }
+    match = organic.each_with_index.find { |result, _| link_matches_domain?(result[:link], domain, match_subdomains: match_subdomains) }
 
     ao = results[:ai_overview]
     ao_sources = ao&.dig(:sources) || []
-    ao_source = ao_sources.find { |source| source[:link]&.include?(domain) }
+    ao_source = ao_sources.find { |source| link_matches_domain?(source[:link], domain, match_subdomains: match_subdomains) }
 
     position, url = if match
       result, = match
@@ -35,11 +35,28 @@ class SerpApiClient
     }
   end
 
-  def check_position(query, domain, location:)
+  def check_position(query, domain, location:, match_subdomains: false)
     results = search(query, location: location)
-    extract_position(results, domain).merge(
+    extract_position(results, domain, match_subdomains: match_subdomains).merge(
       serpapi_search_id: results.dig(:search_metadata, :id),
       raw_response: results.to_json
     )
+  end
+
+  def link_matches_domain?(link, domain, match_subdomains: false)
+    link_host = extract_hostname(link)
+    domain = extract_hostname(domain)
+
+    return false if link_host.blank? || domain.blank?
+
+    link_host == domain || (match_subdomains && link_host.end_with?(".#{domain}"))
+  end
+
+  def extract_hostname(value)
+    hostname = (value.to_s.include?("/") ? URI.parse(value)&.hostname : value).to_s
+
+    hostname.strip.downcase.delete_prefix("www.").delete_suffix(".")
+  rescue URI::InvalidURIError
+    nil
   end
 end

--- a/app/services/serp_api_client.rb
+++ b/app/services/serp_api_client.rb
@@ -45,15 +45,15 @@ class SerpApiClient
 
   def link_matches_domain?(link, domain, match_subdomains: false)
     link_host = extract_hostname(link)
-    domain = extract_hostname(domain)
+    domain_host = extract_hostname(domain)
 
-    return false if link_host.blank? || domain.blank?
+    return false if link_host.blank? || domain_host.blank?
 
-    link_host == domain || (match_subdomains && link_host.end_with?(".#{domain}"))
+    link_host == domain_host || (match_subdomains && link_host.end_with?(".#{domain_host}"))
   end
 
   def extract_hostname(value)
-    hostname = (value.to_s.include?("/") ? URI.parse(value)&.hostname : value).to_s
+    hostname = (value.to_s.include?("/") ? URI.parse(value).hostname : value).to_s
 
     hostname.strip.downcase.delete_prefix("www.").delete_suffix(".")
   rescue URI::InvalidURIError

--- a/app/tools/check_keyword_position.rb
+++ b/app/tools/check_keyword_position.rb
@@ -5,9 +5,10 @@ class CheckKeywordPosition < RubyLLM::Tool
     string :query, description: "The search query/keyword to check"
     string :domain, description: "The domain to find in results (e.g., example.com)"
     string :location, description: "Google country code/location to search from (default: us)", required: false
+    boolean :match_subdomains, description: "Whether to consider results from subdomains as matching", required: false
   end
 
-  def execute(query:, domain:, location: "us")
-    SerpApiClient.new.check_position(query, domain, location: location.presence || "us")
+  def execute(query:, domain:, location: "us", match_subdomains: false)
+    SerpApiClient.new.check_position(query, domain, location: location.presence || "us", match_subdomains: match_subdomains)
   end
 end

--- a/app/views/sites/_form.html.erb
+++ b/app/views/sites/_form.html.erb
@@ -20,6 +20,20 @@
     <%= form.text_field :domain, required: true, placeholder: "example.com", autocomplete: "off" %>
   </div>
 
+  <div class="field">
+    <div class="checkbox-grid">
+      <label class="checkbox-card">
+        <%= form.check_box :match_subdomains %>
+        <span>
+          <span class="checkbox-card-title">Match subdomains</span>
+          <span class="checkbox-card-meta">
+            e.g. <code>blog.example.com</code> will also be matched if you enter <code>example.com</code> for your domain.
+          </span>
+        </span>
+      </label>
+    </div>
+  </div>
+
   <div class="actions">
     <%= form.submit(site.new_record? ? "Create" : "Update", class: "btn") %>
   </div>

--- a/db/migrate/20260626235916_add_match_subdomains_to_sites.rb
+++ b/db/migrate/20260626235916_add_match_subdomains_to_sites.rb
@@ -1,0 +1,5 @@
+class AddMatchSubdomainsToSites < ActiveRecord::Migration[8.1]
+  def change
+    add_column :sites, :match_subdomains, :boolean, default: false, null: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_15_002040) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_26_235916) do
   create_table "chats", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.integer "llm_model_id"
@@ -127,6 +127,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_15_002040) do
   create_table "sites", force: :cascade do |t|
     t.datetime "created_at", null: false
     t.string "domain", null: false
+    t.boolean "match_subdomains", default: false, null: false
     t.string "name", null: false
     t.datetime "updated_at", null: false
     t.index ["domain"], name: "index_sites_on_domain", unique: true

--- a/test/services/serp_api_client_test.rb
+++ b/test/services/serp_api_client_test.rb
@@ -1,0 +1,48 @@
+require "test_helper"
+
+class SerpApiClientTest < ActiveSupport::TestCase
+  setup do
+    @client = SerpApiClient.new
+  end
+
+  test "link matches identical domains" do
+    assert @client.link_matches_domain?("https://example.com/page", "example.com")
+    assert @client.link_matches_domain?("example.com", "https://example.com/about")
+  end
+
+  test "link matches domains with www. disregarded" do
+    assert @client.link_matches_domain?("https://www.example.com/page", "example.com")
+    assert @client.link_matches_domain?("https://example.com/page", "www.example.com")
+  end
+
+  test "link normalizes hostnames before matching" do
+    assert @client.link_matches_domain?("https://EXAMPLE.com/page", "example.com")
+    assert @client.link_matches_domain?("https://EXAMPLE.com/page", "example.com")
+  end
+
+  test "link does not match subdomains by default" do
+    assert_not @client.link_matches_domain?("https://shop.example.com/page", "example.com")
+  end
+
+  test "link matches subdomains when enabled" do
+    assert @client.link_matches_domain?("https://shop.example.com/page", "example.com", match_subdomains: true)
+    assert @client.link_matches_domain?("https://nested.shop.example.com/page", "example.com", match_subdomains: true)
+  end
+
+  test "link matches subdomains when enabled and with www. disregarded" do
+    assert @client.link_matches_domain?("https://www.shop.example.com/page", "example.com", match_subdomains: true)
+    assert @client.link_matches_domain?("https://www.nested.shop.example.com/page", "example.com", match_subdomains: true)
+  end
+
+  test "link does not match unrelated domains" do
+    assert_not @client.link_matches_domain?("https://notexample.com/page", "example.com", match_subdomains: true)
+    assert_not @client.link_matches_domain?("https://example.org/example.com", "example.com", match_subdomains: true)
+  end
+
+  test "link does not match blank or invalid values" do
+    assert_not @client.link_matches_domain?(nil, "example.com")
+    assert_not @client.link_matches_domain?("https://example.com/page", "")
+    assert_not @client.link_matches_domain?("http://%", "example.com")
+    assert_not @client.link_matches_domain?("http://example.com", "     ")
+  end
+end

--- a/test/services/serp_api_client_test.rb
+++ b/test/services/serp_api_client_test.rb
@@ -30,8 +30,8 @@ class SerpApiClientTest < ActiveSupport::TestCase
   end
 
   test "link matches subdomains when enabled and with www. disregarded" do
-    assert @client.link_matches_domain?("https://www.shop.example.com/page", "example.com", match_subdomains: true)
-    assert @client.link_matches_domain?("https://www.nested.shop.example.com/page", "example.com", match_subdomains: true)
+    assert @client.link_matches_domain?("https://www.shop.example.com/page", "www.example.com", match_subdomains: true)
+    assert @client.link_matches_domain?("https://www.nested.shop.example.com/page", "www.example.com", match_subdomains: true)
   end
 
   test "link does not match unrelated domains" do

--- a/test/tools/check_keyword_position_test.rb
+++ b/test/tools/check_keyword_position_test.rb
@@ -11,8 +11,8 @@ class CheckKeywordPositionTest < ActiveSupport::TestCase
   test "delegates to SerpApiClient with default location" do
     client = mock("serp_api_client")
     SerpApiClient.expects(:new).returns(client)
-    client.expects(:check_position).with("iphone 18", "apple.com", location: "us").returns(position: 1)
+    client.expects(:check_position).with("iphone 18", "apple.com", location: "us", match_subdomains: false).returns(position: 1)
 
-    assert_equal({ position: 1 }, CheckKeywordPosition.new.execute(query: "iphone 18", domain: "apple.com", location: ""))
+    assert_equal({ position: 1 }, CheckKeywordPosition.new.execute(query: "iphone 18", domain: "apple.com", location: "", match_subdomains: false))
   end
 end


### PR DESCRIPTION
* Fixes issue with domain matching in result links
  * Previously `include?` would be used to check but it would falsely match if the domain was anywhere in the URL, e.g. for the domain `example.com`, it would also match this URL: `https://site.info/example.com` or this URL: `https://www.weareexample.com/`
* Adds `match_subdomain` attribute to sites
* When toggled on, links from subdomains will also be considered a match for the site, when toggled off, only the exact domain (with `www.` prefixes also considered as matching) will be considered a match

<img width="966" height="511" alt="CleanShot 2026-06-29 at 10 46 06" src="https://github.com/user-attachments/assets/6b8738bc-f465-44f1-89c9-fe668634c120" />
