### PR TITLE
Give agent context about the app

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -75,3 +75,4 @@ group :test do
 end
 
 gem "kramdown", "~> 2.5"
+gem "kramdown-parser-gfm", "~> 1.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -183,6 +183,8 @@ GEM
       zeitwerk (>= 2.6.18, < 3.0)
     kramdown (2.5.2)
       rexml (>= 3.4.4)
+    kramdown-parser-gfm (1.1.0)
+      kramdown (~> 2.0)
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     llhttp-ffi (0.5.1)
@@ -434,6 +436,7 @@ PLATFORMS
   arm-linux-gnu
   arm-linux-musl
   arm64-darwin-23
+  arm64-darwin-25
   x86_64-linux
   x86_64-linux-gnu
   x86_64-linux-musl
@@ -450,6 +453,7 @@ DEPENDENCIES
   jbuilder
   kamal
   kramdown (~> 2.5)
+  kramdown-parser-gfm (~> 1.1)
   mocha
   propshaft
   puma (>= 5.0)
@@ -532,6 +536,7 @@ CHECKSUMS
   json (2.19.9) sha256=9b9025b7cdddafa38d316eca0b2358488e42d417045c1b90d216a9fefe46b79a
   kamal (2.11.0) sha256=1408864425e0dec7e0a14d712a3b13f614e9f3a425b7661d3f9d287a51d7dd75
   kramdown (2.5.2) sha256=1ba542204c66b6f9111ff00dcc26075b95b220b07f2905d8261740c82f7f02fa
+  kramdown-parser-gfm (1.1.0) sha256=fb39745516427d2988543bf01fc4cf0ab1149476382393e0e9c48592f6581729
   language_server-protocol (3.17.0.5) sha256=fd1e39a51a28bf3eec959379985a72e296e9f9acfce46f6a79d31ca8760803cc
   lint_roller (1.1.0) sha256=2c0c845b632a7d172cb849cc90c1bce937a28c5c8ccccb50dfd46a485003cc87
   llhttp-ffi (0.5.1) sha256=9a25a7fc19311f691a78c9c0ac0fbf4675adbd0cca74310228fdf841018fa7bc

--- a/app/agents/seo_agent.rb
+++ b/app/agents/seo_agent.rb
@@ -16,12 +16,34 @@ class SeoAgent < RubyLLM::Agent
 
     When presenting results, be concise and structured: lead with the answer,
     then list supporting positions, URLs, and any notable changes.
+
+    When asked for help how to do something relating to keywords/rank tracking,
+    always assume that the user is asking about it in SerpTrail and not another
+    tool for that purpose. You should not qualify everything by saying "in
+    SerpTrail" or "SerpTrail XYZ" etc for behaviors being described in
+    SerpTrail. The user is currently logged into SerpTrail.
+
+    If the user asks about a known site behavior, call the SiteBehavior tool
+    before answering. The user may ask in any language. Match their meaning to
+    the canonical behavior IDs. Use the returned guidance to answer naturally
+    in the user's language. If the user is unaware of a behavior or a screen,
+    if they're asking a "how to" style question or something very vague, then
+    you should markdown link to the relevant page(s)/route(s) in your response.
+    Paths/routes returned from the SiteBehavior tool are relative to the root
+    of the SerpTrail app, so you they should be used as relative markdown links
+    and not as hash fragments (i.e. do not use `#/example/route`).
+
+    Do not call SiteBehavior for general conversation or unrelated questions
+    unless your answer would be significantly enhanced by having specifics
+    about the relevant site behavior. Do not mention internal behavior IDs to
+    the user, they're irrelevant to them.
   PROMPT
 
   tools CheckKeywordPosition,
         SearchGoogle,
         KeywordHistory,
-        FindCompetitors
+        FindCompetitors,
+        SiteBehavior
 
   def self.create!(...)
     configure_openai_api_key

--- a/app/agents/seo_agent.rb
+++ b/app/agents/seo_agent.rb
@@ -23,19 +23,19 @@ class SeoAgent < RubyLLM::Agent
     SerpTrail" or "SerpTrail XYZ" etc for behaviors being described in
     SerpTrail. The user is currently logged into SerpTrail.
 
-    If the user asks about a known site behavior, call the SiteBehavior tool
+    If the user asks about a known site behavior, call the AppContext tool
     before answering. The user may ask in any language. Match their meaning to
-    the canonical behavior IDs. Use the returned guidance to answer naturally
+    the canonical context IDs. Use the returned guidance to answer naturally
     in the user's language. If the user is unaware of a behavior or a screen,
     if they're asking a "how to" style question or something very vague, then
     you should markdown link to the relevant page(s)/route(s) in your response.
-    Paths/routes returned from the SiteBehavior tool are relative to the root
+    Paths/routes returned from the AppContext tool are relative to the root
     of the SerpTrail app, so you they should be used as relative markdown links
     and not as hash fragments (i.e. do not use `#/example/route`).
 
-    Do not call SiteBehavior for general conversation or unrelated questions
+    Do not call AppContext for general conversation or unrelated questions
     unless your answer would be significantly enhanced by having specifics
-    about the relevant site behavior. Do not mention internal behavior IDs to
+    about the relevant app context. Do not mention internal context IDs to
     the user, they're irrelevant to them.
   PROMPT
 
@@ -43,7 +43,7 @@ class SeoAgent < RubyLLM::Agent
         SearchGoogle,
         KeywordHistory,
         FindCompetitors,
-        SiteBehavior
+        AppContext
 
   def self.create!(...)
     configure_openai_api_key

--- a/app/helpers/chats_helper.rb
+++ b/app/helpers/chats_helper.rb
@@ -1,6 +1,6 @@
 module ChatsHelper
   def markdown(text)
-    html = Kramdown::Document.new(text.to_s, hard_wrap: true).to_html
+    html = Kramdown::Document.new(text.to_s, hard_wrap: true, input: "GFM").to_html
     sanitized_html = sanitize(
       html,
       tags: %w[p br strong em a ul ol li code pre blockquote h1 h2 h3 h4 h5 h6 hr],

--- a/app/helpers/chats_helper.rb
+++ b/app/helpers/chats_helper.rb
@@ -1,10 +1,23 @@
 module ChatsHelper
   def markdown(text)
     html = Kramdown::Document.new(text.to_s, hard_wrap: true).to_html
-    sanitize(
+    sanitized_html = sanitize(
       html,
       tags: %w[p br strong em a ul ol li code pre blockquote h1 h2 h3 h4 h5 h6 hr],
       attributes: %w[href title]
     )
+    open_markdown_links_in_top_frame(sanitized_html)
+  end
+
+  private
+
+  def open_markdown_links_in_top_frame(html)
+    fragment = Loofah.fragment(html.to_s)
+
+    fragment.css("a[href]").each do |link|
+      link["data-turbo-frame"] = "_top"
+    end
+
+    fragment.to_s.html_safe
   end
 end

--- a/app/tools/app_context.rb
+++ b/app/tools/app_context.rb
@@ -1,14 +1,14 @@
-class SiteBehavior < RubyLLM::Tool
+class AppContext < RubyLLM::Tool
   include Rails.application.routes.url_helpers
 
   desc <<~TEXT
-    Fetches extra internal guidance for known SerpTrail site behaviors.
+    Fetches extra internal guidance for known SerpTrail app context/behaviors.
 
     Call this before answering if the user is asking about anything relating to
-    a specific site behavior or if a response would be enhanced by having extra
-    guidance or specifics about a site behavior.
+    a specific app context or if a response would be enhanced by having extra
+    guidance or specifics about an app context.
 
-    Known behaviors:
+    Known contexts:
       * add-site: Anything relating to adding or tracking a new site
       * sites: Anything relating to editing or managing sites
       * add-keyword: Anything relating to creating/adding keywords to track
@@ -20,11 +20,11 @@ class SiteBehavior < RubyLLM::Tool
   TEXT
 
   params do
-    string :behavior_id, description: "The ID of the behavior to fetch guidance for"
+    string :context_id, description: "The ID of the context to fetch guidance for"
   end
 
-  def execute(behavior_id:)
-    case behavior_id
+  def execute(context_id:)
+    case context_id
     when "add-site"
       <<~TEXT
         Add site route: `#{new_site_path}`
@@ -95,7 +95,7 @@ class SiteBehavior < RubyLLM::Tool
           * configure your OpenAI API key
       TEXT
     else
-      "No specific guidance available for this behavior ID."
+      "No specific guidance available for this context ID."
     end
   end
 end

--- a/app/tools/app_context.rb
+++ b/app/tools/app_context.rb
@@ -13,8 +13,8 @@ class AppContext < RubyLLM::Tool
       * sites: Anything relating to editing or managing sites
       * add-keyword: Anything relating to creating/adding keywords to track
       * keywords: Anything relating to editing, or managing keywords
-      * views: Anything relating to creating/adding, editing, or managing
-               custom views/charts
+      * add-view: Anything relating to creating/adding custom views/charts
+      * views: Anything relating to editing, or managing custom views/charts
       * settings: Anything relating to configuring or managing SerpTrail
                   settings, including API keys, user accounts, and preferences
   TEXT
@@ -73,6 +73,19 @@ class AppContext < RubyLLM::Tool
           * edit the keyword's query, locations, check frequency, and tracked
             sites
           * view a specific site's tracking history for that keyword
+      TEXT
+    when "add-view"
+      <<~TEXT
+        Add view route: `#{new_view_path}`
+        How to get there:
+          * go to the "Views" page from the top menu, then click "Add"
+        Fields:
+          * Series 1 [required]
+          * Series 2 [required]
+          * Each series has the following fields:
+            * Site [required]
+            * Keyword [required]
+            * Location [required]
       TEXT
     when "views"
       <<~TEXT

--- a/app/tools/site_behavior.rb
+++ b/app/tools/site_behavior.rb
@@ -1,0 +1,101 @@
+class SiteBehavior < RubyLLM::Tool
+  include Rails.application.routes.url_helpers
+
+  desc <<~TEXT
+    Fetches extra internal guidance for known SerpTrail site behaviours.
+
+    Call this before answering if the user is asking about anything relating to
+    a specific site behavior or if a response would be enhanced by having extra
+    guidance or specifics about a site behavior.
+
+    Known behaviors:
+      * add-site: Anything relating to adding or tracking a new site
+      * sites: Anything relating to editing or managing sites
+      * add-keyword: Anything relating to creating/adding keywords to track
+      * keywords: Anything relating to editing, or managing keywords
+      * views: Anything relating to creating/adding, editing, or managing
+               custom views/charts
+      * settings: Anything relating to configuring or managing SerpTrail
+                  settings, including API keys, user accounts, and preferences
+  TEXT
+
+  params do
+    string :behavior_id, description: "The ID of the behavior to fetch guidance for"
+  end
+
+  def execute(behavior_id:)
+    case behavior_id
+    when "add-site"
+      <<~TEXT
+        Add site route: `#{new_site_path}`
+        How to get there:
+          * go to the "Sites" page from the top menu, then click "Add"
+        Fields:
+          * Name [required]
+          * Domain [required]
+          * Match subdomains [optional, defaults to false]
+      TEXT
+    when "sites"
+      <<~TEXT
+        Sites index route: `#{sites_path}`
+        How to get there:
+          * go to the "Sites" page from the top menu, then click on a site
+        What to do there:
+          * view the site's tracked keywords and their current positions
+          * edit the site's name, domain, or subdomain matching setting
+          * delete the site and all its associated keywords and checks
+      TEXT
+    when "add-keyword"
+      <<~TEXT
+        Add keyword (not specific to a single site) route: `#{new_keyword_path}`
+        How to get there:
+          * go to the "Keywords" page from the top menu, then click "Add"; OR
+          * if viewing a specific site, click "Add" in the top right corner
+        Fields:
+          * Query [required]
+          * Locations [optional, defaults to US]
+          * Check frequency [optional, defaults to daily]
+          * Sites to track [optional, can be set later] [not visible if adding
+            from the site page]
+      TEXT
+    when "keywords"
+      <<~TEXT
+        Keywords index (not specific to a single site) route: `#{keywords_path}`
+        How to get there:
+          * go to the "Keywords" page from the top menu, then click on a
+            keyword; OR
+          * if viewing a specific site, click on a keyword in the site's
+            keyword list
+        What to do there:
+          * see a list of the search runs for that keyword
+          * see the latest (and historic) results for the keyword by location
+          * trigger a manual check for the keyword
+          * edit the keyword's query, locations, check frequency, and tracked
+            sites
+          * view a specific site's tracking history for that keyword
+      TEXT
+    when "views"
+      <<~TEXT
+        Views index route: `#{views_path}`
+        How to get there:
+          * go to the "Views" page from the top menu, then click "Add"
+        What to do there:
+          * create a custom view containing tracked keywords and their
+            positions
+          * choose which sites and keywords to include in the view
+          * choose which locations to include in the view
+      TEXT
+    when "settings"
+      <<~TEXT
+        Settings route: `#{settings_path}`
+        How to get there:
+          * go to the "Settings" page from the top menu (the gear icon)
+        What to do there:
+          * configure your SerpApi API key
+          * configure your OpenAI API key
+      TEXT
+    else
+      "No specific guidance available for this behavior ID."
+    end
+  end
+end

--- a/app/tools/site_behavior.rb
+++ b/app/tools/site_behavior.rb
@@ -2,7 +2,7 @@ class SiteBehavior < RubyLLM::Tool
   include Rails.application.routes.url_helpers
 
   desc <<~TEXT
-    Fetches extra internal guidance for known SerpTrail site behaviours.
+    Fetches extra internal guidance for known SerpTrail site behaviors.
 
     Call this before answering if the user is asking about anything relating to
     a specific site behavior or if a response would be enhanced by having extra

--- a/test/agents/seo_agent_test.rb
+++ b/test/agents/seo_agent_test.rb
@@ -4,7 +4,7 @@ class SeoAgentTest < ActiveSupport::TestCase
   test "registers SEO tools with RubyLLM" do
     agent = SeoAgent.new
 
-    assert_equal [ :check_keyword_position, :search_google, :keyword_history, :find_competitors ], agent.chat.tools.keys
+    assert_equal [ :check_keyword_position, :search_google, :keyword_history, :find_competitors, :site_behavior ], agent.chat.tools.keys
   end
 
   test "configures RubyLLM with tenant OpenAI key" do

--- a/test/agents/seo_agent_test.rb
+++ b/test/agents/seo_agent_test.rb
@@ -4,7 +4,7 @@ class SeoAgentTest < ActiveSupport::TestCase
   test "registers SEO tools with RubyLLM" do
     agent = SeoAgent.new
 
-    assert_equal [ :check_keyword_position, :search_google, :keyword_history, :find_competitors, :site_behavior ], agent.chat.tools.keys
+    assert_equal [ :check_keyword_position, :search_google, :keyword_history, :find_competitors, :app_context ], agent.chat.tools.keys
   end
 
   test "configures RubyLLM with tenant OpenAI key" do

--- a/test/controllers/chats_controller_test.rb
+++ b/test/controllers/chats_controller_test.rb
@@ -79,13 +79,14 @@ class ChatsControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "renders chat messages as sanitized markdown" do
-    with_stubbed_chat_answers("**Summary**\n\n- Apple is #1\n- Best Buy is #5\n\n<script>alert('xss')</script>") do
+    with_stubbed_chat_answers("**Summary**\n\n- Apple is #1\n- Best Buy is #5\n\n[Open settings](/settings)\n\n<script>alert('xss')</script>") do
       post chat_url, params: { chat: { message: "Format this" } }, headers: @headers
     end
 
     assert_response :success
     assert_select ".chat-message-assistant strong", text: "Summary"
     assert_select ".chat-message-assistant li", text: "Apple is #1"
+    assert_select ".chat-message-assistant a[href='#{settings_path}'][data-turbo-frame='_top']", text: "Open settings"
     assert_select ".chat-message-assistant script", count: 0
   end
 


### PR DESCRIPTION
- Updates the chat agent to give it context about the app itself (e.g. how to add a site, how to add a keyword, etc.) to allow it to give better responses
- Adjusts markdown rendering to add `data-turbo-frame="_top"` to all links so links from chat work
- Added `kramdown-parser-gfm` to allow rendering of the more relaxed markdown results we get back from LLM calls (e.g. resolves hyphen lists that begin immediately after a paragraph rather than having a blank line separating the previous paragraph and the new hyphen list)

There's probably room for improvement here especially in terms of token count, but it gives significantly better results when asking questions about the app itself as a result of this.

## Screenshots

<details>
<summary>Example 1: "How do I setup a site?"</summary>

**Before:**
<img width="368" height="612" alt="CleanShot 2026-06-29 at 13 28 46" src="https://github.com/user-attachments/assets/d17f5086-dea9-43c8-abac-188dece26428" />

**After:**
<img width="364" height="607" alt="CleanShot 2026-06-29 at 13 27 58" src="https://github.com/user-attachments/assets/35d033b8-f9d6-4e43-af0d-61a7820965c0" />
</details>

<details>
<summary>Example 2: "キーワードを追跡するにはどうすればよいですか？"</summary>

**Before:**
<img width="811" height="677" alt="CleanShot 2026-06-29 at 13 35 17" src="https://github.com/user-attachments/assets/4fdf03b5-4766-4e89-9acf-8b03f789608e" />

**After:**
<img width="804" height="671" alt="CleanShot 2026-06-29 at 13 37 46" src="https://github.com/user-attachments/assets/aa33229d-40cc-48b7-860b-848e59565c67" />
</details>